### PR TITLE
Added a method to use the caching method of lessphp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /vendor
 composer.lock
 .DS_Store
+/nbproject/private/
+*.properties
+project.xml

--- a/src/Zizaco/Lessy/Lessy.php
+++ b/src/Zizaco/Lessy/Lessy.php
@@ -183,4 +183,52 @@ class Lessy
         );
     }
 
+    /**
+     * complies and caches the less files into one css file
+     */
+    public function cachedCompileLessFile()
+    {
+
+        $root = $this->_app['path'] . '/';
+        $inputFile = $this->_app['config']->get('lessy::originFile');
+        $outputFile = $this->_app['config']->get('lessy::destinationFile');
+
+        if (empty($inputFile))
+            $inputFile = 'less/main.less';
+
+        if (empty($outputFile))
+            $outputFile = '../public/assets/css/main.css';
+
+        $inputFile = $root . $inputFile;
+        $outputFile = $root . $outputFile;
+
+        // cachedCompile method takes an optional second argument, $force.
+        // Passing in true will cause the input to always be recompiled.
+        $force = false;
+
+        // lessjs (default) — Same style used in LESS for JavaScript
+        // compressed — Compresses all the unrequired whitespace
+        // classic — lessphp’s original formatter
+        $formatter = $this->_app['config']->get('lessy::formatter');
+
+        // load the cache
+        $cacheFile = $inputFile . ".cache";
+
+        if (file_exists($cacheFile)) {
+            $cache = unserialize(file_get_contents($cacheFile));
+        } else {
+            $cache = $inputFile;
+        }
+
+        $less = new lessc;
+        $less->setFormatter($formatter);
+
+        $newCache = $less->cachedCompile($cache, $force);
+
+        if (!is_array($cache) || $newCache["updated"] > $cache["updated"]) {
+            file_put_contents($cacheFile, serialize($newCache));
+            file_put_contents($outputFile, $newCache['compiled']);
+        }
+    }
+
 }

--- a/src/Zizaco/Lessy/LessyServiceProvider.php
+++ b/src/Zizaco/Lessy/LessyServiceProvider.php
@@ -31,7 +31,12 @@ class LessyServiceProvider extends ServiceProvider {
 			// Compiles less file if manual_compile_only is not enabled
 			if (! $this->app['config']->get('lessy::manual_compile_only'))
 			{
-				$lessy->compileLessFiles();
+                // compiles and caches the less files into a single css file
+                if($this->app['config']->get('lessy::single_file')) {
+                    $lessy->cachedCompileLessFile();
+                } else {
+                    $lessy->compileLessFiles();
+                }
 			}
 		}
 	}

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -12,10 +12,9 @@ return array(
     |
     */
 
-    'origin'        => 'less',
+    'origin'          => 'less',
 
-    'destination'   => '../public/assets/css',
-
+    'destination'     => '../public/assets/css',
 
     /*
     |--------------------------------------------------------------------------
@@ -45,5 +44,26 @@ return array(
     */
 
     'manual_compile_only' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Singe File
+    |--------------------------------------------------------------------------
+    |
+    | This option will force all less output into a single file and cache it.
+    |
+    */
+
+    'single_file'     => 'false',
+
+    // source file responisble for glueing together the less files into a single
+    // css output file
+    'originFile'      => 'less/main.less',
+
+    // file to be compiled from the less source files
+    'destinationFile' => '../public/assets/css/main.css',
+
+    // the formatting for the outputted css file
+    'formatter'       => 'lessjs',
 
 );


### PR DESCRIPTION
Added a new option to compile the less files. This option will allow the
complation of several less files into a single css file and cache it. It
also allows for the css file to be compressed.

Signed-off-by: Craig Weiser craig.weiser@kemweb.de
